### PR TITLE
Fix docstring: `:value` should be `:return`

### DIFF
--- a/src/mockery/core.clj
+++ b/src/mockery/core.clj
@@ -127,7 +127,7 @@
   -- `:target` (required): a symbol or a keyword points to a target
   function to mock. May include a namespace (be full-qualified).
 
-  -- `:value`: any value to return from a mocked function. If it's a
+  -- `:return`: any value to return from a mocked function. If it's a
   function by itself (defn, fn or #(...)), it will be called
   afterwards.
 


### PR DESCRIPTION
I got bitten by this by only looking at the docstring of `with-mock` :)